### PR TITLE
Fixed Guava vulnerability

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>31.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.report</groupId>
     <artifactId>report</artifactId>
     <name>report</name>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.2-SNAPSHOT</version>
     <description>Report system</description>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.report</groupId>
     <artifactId>report</artifactId>
     <name>report</name>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
     <description>Report system</description>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Based on dependabot alert about Guava library vulnerability in 29.0 version.